### PR TITLE
Add possibility to update screenshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,11 @@ If you have multiple screenshots within the same test case, you need to give the
 
 The general rule for screenshot naming is: `[Test Suit Name] -- [Test Name] -- [Screenshot Name].png`
 
+
+## Update screenshots
+
+If you want to update the base screenshots with the new generated set, put the `updateScreenshots` parameter to Cypress config.
+
 ## Todos
 
 - [x] ~Crop screenshots to only contain relevant viewport (see [https://github.com/cypress-io/cypress/issues/1810](https://github.com/cypress-io/cypress/issues/181))~

--- a/src/index.js
+++ b/src/index.js
@@ -92,12 +92,17 @@ function matchScreenshot (name, options = {}) {
           .then((result) => {
             console.log(`Matched screenshot - Passed: ${result.stdout}`);
             const matches = result.stdout === 'Yay';
-            assert.isTrue(matches, 'Screenshots match');
-            cy.exec(
-              `mv "${CYPRESS_SCREENSHOT_FOLDER}/new/${fileName}.png" ` +
-                `"${CYPRESS_SCREENSHOT_FOLDER}/${fileName}.png"`,
-              { log: false }
-            );
+            if (Cypress.config('updateScreenshots') || matches) {
+              cy.exec(
+                `mv "${CYPRESS_SCREENSHOT_FOLDER}/new/${fileName}.png" ` +
+                  `"${CYPRESS_SCREENSHOT_FOLDER}/${fileName}.png"`,
+                { log: false }
+              );
+              cy.exec(`rm "${CYPRESS_SCREENSHOT_FOLDER}/diff/${fileName}.png"`, { log: false });
+            }
+            if (!Cypress.config('updateScreenshots')) {
+              assert.isTrue(matches, 'Screenshots match');
+            }
           });
       } else {
         console.log('No previous screenshot found! Match passed!');


### PR DESCRIPTION
When there is diff, we need to have automated way to replace the base with new screenshots. That can happen when new feature added and the new screenshot is valid.