### PR TITLE
Fix passing zero value for threshold and allow specifying threshold type

### DIFF
--- a/src/diff-screenshot.js
+++ b/src/diff-screenshot.js
@@ -9,14 +9,19 @@ const resolve = (name) => {
   return path.resolve(__dirname, `../../../${name}`);
 };
 
-const threshold = argv.threshold ? parseFloat(argv.threshold) : 0.005;
-
+const threshold = argv.threshold !== undefined ? argv.threshold : 0.005;
+let thresholdType;
+switch(argv.thresholdType) {
+  case 'pixel': thresholdType = Blink.THRESHOLD_PIXEL; break;
+  case 'percent':
+  default: thresholdType = Blink.THRESHOLD_PERCENT; break;
+}
 const diff = new Blink({
   imageAPath: resolve(argv.pathOld),
   imageBPath: resolve(argv.pathNew),
   imageOutputPath: resolve(argv.target),
-  thresholdType: Blink.THRESHOLD_PERCENT,
-  threshold
+  thresholdType,
+  threshold,
 });
 
 diff.run((error, result) => {

--- a/src/index.js
+++ b/src/index.js
@@ -86,7 +86,8 @@ function matchScreenshot (name, options = {}) {
               `--pathOld="${CYPRESS_SCREENSHOT_FOLDER}/${fileName}.png" ` +
               `--pathNew="${CYPRESS_SCREENSHOT_FOLDER}/new/${fileName}.png" ` +
               `--target="${CYPRESS_SCREENSHOT_FOLDER}/diff/${fileName}.png" ` +
-              `--threshold=${options.threshold || 0.005}`,
+              `--threshold=${options.threshold} ` +
+              `--thresholdType=${options.thresholdType} `,
             { log: false }
           )
           .then((result) => {


### PR DESCRIPTION
If threshold is set to `0` it is replaced with default value `0.005`. Fixing that and moving the default value to single place.
Adding ability to set threshold type: pixel/percent.