### PR TITLE
Added space after filename when calling `cypress-crop-screenshot`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -40,7 +40,7 @@ function takeScreenshot (name) {
   );
   cy.exec(
     `cypress-crop-screenshot ` +
-      `--path="${path.join(cypressPaths.ROOT_FOLDER, cypressPaths.SCREENSHOT_FOLDER, `${name}.png`)}"` +
+      `--path="${path.join(cypressPaths.ROOT_FOLDER, cypressPaths.SCREENSHOT_FOLDER, `${name}.png`)}" ` +
       `--top=${frame.top} ` +
       `--left=${frame.left} ` +
       `--width=${frame.width} ` +


### PR DESCRIPTION
The missing space after the filename corrupted the filename by adding the next parameter to the file. This made the cropping fail.