### PR TITLE
Change updateScreenshots config to cause tests to fail

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -106,6 +106,8 @@ function matchScreenshot (name, options = {}) {
                 }
                 if (!Cypress.config('updateScreenshots')) {
                   assert.isTrue(matches, 'Screenshots match');
+                } else {
+                  expect.fail();
                 }
               });
           } else {


### PR DESCRIPTION
To avoid false positives, it makes sense to fail tests when updating screenshots. This way there's no way you could accidentally leave updateScreenshots set to true without noticing.